### PR TITLE
new optional parameters to configure exchange endpoint

### DIFF
--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -150,6 +150,18 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
             if (exchangeParameters.getProxyPort() != null) {
                 exchangeSpecification.setProxyPort(exchangeParameters.getProxyPort());
             }
+            if (exchangeParameters.getSslUri() != null) {
+                exchangeSpecification.setSslUri(exchangeParameters.getSslUri());
+            }
+            if (exchangeParameters.getPlainTextUri() != null) {
+                exchangeSpecification.setPlainTextUri(exchangeParameters.getPlainTextUri());
+            }
+            if (exchangeParameters.getHost() != null) {
+                exchangeSpecification.setHost(exchangeParameters.getHost());
+            }
+            if (exchangeParameters.getPort() != null) {
+                exchangeSpecification.setPort(Integer.parseInt(exchangeParameters.getPort()));
+            }
 
             // Creates XChange services.
             final Exchange xChangeExchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/parameters/ExchangeParameters.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/parameters/ExchangeParameters.java
@@ -21,6 +21,8 @@ import javax.validation.constraints.NotNull;
 @ConfigurationProperties(prefix = "cassandre.trading.bot.exchange")
 public class ExchangeParameters {
 
+    //TODO PARAMETER_EXCHANGE_* are used only in tests, move it where they belong to
+
     /** Exchange name parameter. */
     public static final String PARAMETER_EXCHANGE_NAME = "cassandre.trading.bot.exchange.name";
 
@@ -41,6 +43,18 @@ public class ExchangeParameters {
 
     /** Proxy port. */
     public static final String PARAMETER_EXCHANGE_PROXY_PORT = "cassandre.trading.bot.exchange.proxyPort";
+
+    /** secure API endpoint parameter. */
+    public static final String PARAMETER_EXCHANGE_SSL_URI = "cassandre.trading.bot.exchange.sslUri";
+
+    /** plain text API endpoint parameter. */
+    public static final String PARAMETER_EXCHANGE_PLAIN_TEXT_URI = "cassandre.trading.bot.exchange.plainTextUri";
+
+    /** exchange port parameter. */
+    public static final String PARAMETER_EXCHANGE_HOST = "cassandre.trading.bot.exchange.host";
+
+    /** exchange port parameter. */
+    public static final String PARAMETER_EXCHANGE_PORT = "cassandre.trading.bot.exchange.port";;
 
     /** Exchange name. For example : coinbase, kraken, kucoin. */
     @NotEmpty(message = "Exchange name required, for example : coinbase, kraken, kucoin...")
@@ -67,6 +81,18 @@ public class ExchangeParameters {
 
     /** Proxy port. */
     private Integer proxyPort;
+
+    /** secure API endpoint. */
+    private String sslUri;
+
+    /** plain text API endpoint. */
+    private String plainTextUri;
+
+    /** exchange port parameter. */
+    private String host;
+
+    /** exchange port parameter. */
+    private String port;
 
     /** Modes. */
     @Valid

--- a/spring-boot-starter/autoconfigure/src/main/resources/application.properties
+++ b/spring-boot-starter/autoconfigure/src/main/resources/application.properties
@@ -9,6 +9,10 @@ cassandre.trading.bot.exchange.secret=5f6e91e0-796b-4947-b75e-eaa5c06b6bed
 # Xchange specific parameters - uncomment if required.
 # cassandre.trading.bot.exchange.proxyHost=127.0.0.1
 # cassandre.trading.bot.exchange.proxyPort=4780
+# cassandre.trading.bot.exchange.sslUri=https://someexchange.com
+# cassandre.trading.bot.exchange.plainTextUri=http://someexchange.com
+# cassandre.trading.bot.exchange.host=www.someexchange.com
+# cassandre.trading.bot.exchange.port=443
 #
 # Modes.
 cassandre.trading.bot.exchange.modes.sandbox=true

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/configuration/exchange/ExchangeSpecificationTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/configuration/exchange/ExchangeSpecificationTest.java
@@ -16,13 +16,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_HOST;
+import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_PLAIN_TEXT_URI;
+import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_PORT;
 import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_PROXY_HOST;
 import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_PROXY_PORT;
+import static tech.cassandre.trading.bot.util.parameters.ExchangeParameters.PARAMETER_EXCHANGE_SSL_URI;
 
 @DisplayName("Configuration - Exchange - Specific exchange parameters")
 @Configuration({
         @Property(key = PARAMETER_EXCHANGE_PROXY_HOST, value = "127.0.0.1"),
-        @Property(key = PARAMETER_EXCHANGE_PROXY_PORT, value = "4780")
+        @Property(key = PARAMETER_EXCHANGE_PROXY_PORT, value = "4780"),
+        @Property(key = PARAMETER_EXCHANGE_SSL_URI, value = "https://someexchange.com"),
+        @Property(key = PARAMETER_EXCHANGE_PLAIN_TEXT_URI, value = "http://someexchange.com"),
+        @Property(key = PARAMETER_EXCHANGE_HOST, value = "www.someexchange.com"),
+        @Property(key = PARAMETER_EXCHANGE_PORT, value = "443")
 })
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 public class ExchangeSpecificationTest extends BaseTest {
@@ -32,11 +40,21 @@ public class ExchangeSpecificationTest extends BaseTest {
     @DisplayName("Check proxy host & port")
     public void checkProxyAndHostParameters() {
         try {
+            //TODO do not init directly, delegate it to test framework
             SpringApplication application = new SpringApplication(CassandreTradingBot.class);
+
+            //TODO catch exception like - Assertions.assertThrows(ConnectException.class, ()->application.run());
+            //TODO do not use "run" directly, delegate it to test framework
             final ConfigurableApplicationContext run = application.run();
+
             final ExchangeParameters exchangeParameters = run.getBean(ExchangeParameters.class);
+            //TODO this code is never called... as exception is thrown during "application.run()" call
             assertEquals("127.0.0.1", exchangeParameters.getProxyHost());
             assertEquals(4780, exchangeParameters.getProxyPort());
+            assertEquals("https://someexchange.com", exchangeParameters.getSslUri());
+            assertEquals("http://someexchange.com", exchangeParameters.getPlainTextUri());
+            assertEquals("www.someexchange.com", exchangeParameters.getHost());
+            assertEquals(443, exchangeParameters.getPort());
             fail("No exception raised");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("java.net.ConnectException"));


### PR DESCRIPTION
In general, I find it somehow strange that the project positioned itself as a framework initialize and connects to a exchange run upon application start-up. I guess it could be more beneficial to grab all necessary settings (like exchange properties) and expose some bean which is ready to make a connect. This approach to make a connect right away on the application starts leads to inability to test initialization properties properly - as here   https://github.com/cassandre-tech/cassandre-trading-bot/blob/d2fa95395e1b54bcac09d2cbd6ef1bc89456525f/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/configuration/exchange/ExchangeSpecificationTest.java#L51