### PR TITLE
Gemini exchange support fix

### DIFF
--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -248,6 +248,8 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
         // Coinbase pro specific.
         if (exchangeParameters.getName().equalsIgnoreCase("coinbasePro")) {
             return "org.knowm.xchange.coinbasepro.CoinbaseProExchange";
+        } else if (exchangeParameters.getName().equalsIgnoreCase("gemini")) {
+            return "org.knowm.xchange.gemini.v1.GeminiExchange";
         }
 
         // Returns the XChange package name.


### PR DESCRIPTION
Gemini adapter has not standard package structure. Added the workaround (similar to coinbase) so that init can work.
But to be honest why "name"? why not fully qualified class name?