### PR TITLE
584 cancelorder fix v2

### DIFF
--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeService.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeService.java
@@ -1,5 +1,6 @@
 package tech.cassandre.trading.bot.service;
 
+import tech.cassandre.trading.bot.domain.Order;
 import tech.cassandre.trading.bot.dto.trade.OrderCreationResultDTO;
 import tech.cassandre.trading.bot.dto.trade.OrderDTO;
 import tech.cassandre.trading.bot.dto.trade.TradeDTO;
@@ -71,7 +72,7 @@ public interface TradeService {
      *
      * @param orderId order id
      * @return true if cancelled
-     * @deprecated use {@link #cancelOrder(String, CurrencyPairDTO)}
+     * @deprecated use {@link #cancelOrder(Order)}
      */
     @Deprecated(forRemoval = true)
     boolean cancelOrder(String orderId);
@@ -79,11 +80,10 @@ public interface TradeService {
     /**
      * Cancel order.
      *
-     * @param orderId order id
-     * @param currencyPair target currency pair
+     * @param order the order to cancel
      * @return true if cancelled
      */
-    boolean cancelOrder(String orderId, CurrencyPairDTO currencyPair);
+    boolean cancelOrder(Order order);
 
     /**
      * Get orders from exchange.

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeService.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeService.java
@@ -71,8 +71,19 @@ public interface TradeService {
      *
      * @param orderId order id
      * @return true if cancelled
+     * @deprecated use {@link #cancelOrder(String, CurrencyPairDTO)}
      */
+    @Deprecated(forRemoval = true)
     boolean cancelOrder(String orderId);
+
+    /**
+     * Cancel order.
+     *
+     * @param orderId order id
+     * @param currencyPair target currency pair
+     * @return true if cancelled
+     */
+    boolean cancelOrder(String orderId, CurrencyPairDTO currencyPair);
 
     /**
      * Get orders from exchange.

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeServiceXChangeImplementation.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/TradeServiceXChangeImplementation.java
@@ -1,8 +1,10 @@
 package tech.cassandre.trading.bot.service;
 
 import org.apache.commons.lang3.time.DateUtils;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
+import org.knowm.xchange.service.trade.params.DefaultCancelOrderByCurrencyPairAndIdParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsAll;
 import tech.cassandre.trading.bot.domain.Order;
 import tech.cassandre.trading.bot.dto.trade.OrderCreationResultDTO;
@@ -245,6 +247,25 @@ public class TradeServiceXChangeImplementation extends BaseService implements Tr
 
     @Override
     @SuppressWarnings("checkstyle:DesignForExtension")
+    public boolean cancelOrder(final String orderId, final CurrencyPairDTO currencyPair) {
+        logger.debug("TradeService - Canceling order {}", orderId);
+        if (orderId != null) {
+            try {
+                logger.debug("TradeService - Successfully canceled order {} : {}", orderId, currencyPair);
+                var params = new DefaultCancelOrderByCurrencyPairAndIdParams(dto2xchange(currencyPair), orderId);
+                return tradeService.cancelOrder(params);
+            } catch (Exception e) {
+                logger.error("TradeService - Error canceling order {}: {}", orderId, e.getMessage());
+                return false;
+            }
+        } else {
+            logger.error("TradeService - Error canceling order, order id provided is null");
+            return false;
+        }
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:DesignForExtension")
     public Set<OrderDTO> getOrders() {
         logger.debug("TradeService - Getting orders from exchange");
         try {
@@ -329,4 +350,7 @@ public class TradeServiceXChangeImplementation extends BaseService implements Tr
         return results;
     }
 
+    private CurrencyPair dto2xchange(final CurrencyPairDTO source) {
+        return new CurrencyPair(source.getBaseCurrency().getCurrencyCode(), source.getQuoteCurrency().getCurrencyCode());
+    }
 }

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/GenericCassandreStrategy.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/GenericCassandreStrategy.java
@@ -205,7 +205,7 @@ public abstract class GenericCassandreStrategy implements CassandreStrategyInter
                 .collect(Collectors.toMap(TickerDTO::getCurrencyPair, Function.identity(), (id, value) -> id, LinkedHashMap::new));
 
         // We update the values of the last tickers that can be found in the strategy.
-        tickersUpdates.values().forEach(ticker -> lastTickers.put(ticker.getCurrencyPair(), ticker));
+        lastTickers.putAll(tickersUpdates);
 
         // We notify the strategy.
         onTickersUpdates(tickersUpdates);

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/GenericCassandreStrategy.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/GenericCassandreStrategy.java
@@ -503,23 +503,10 @@ public abstract class GenericCassandreStrategy implements CassandreStrategyInter
      *
      * @param id id
      * @return true if cancelled
-     * @deprecated use {@link #cancelOrder(long, CurrencyPairDTO)}
      */
-    @Deprecated( forRemoval = true )
     boolean cancelOrder(final long id) {
         final Optional<Order> order = orderRepository.findById(id);
-        return order.filter(value -> cancelOrder(value.getOrderId())).isPresent();
-    }
-
-    /**
-     * Cancel order.
-     *
-     * @param id id
-     * @return true if cancelled
-     */
-    boolean cancelOrder(final long id, final CurrencyPairDTO currencyPair) {
-        final Optional<Order> order = orderRepository.findById(id);
-        return order.filter(value -> cancelOrder(value.getOrderId(), currencyPair)).isPresent();
+        return order.map(this::cancelOrder).orElse(false);
     }
 
     /**
@@ -527,7 +514,7 @@ public abstract class GenericCassandreStrategy implements CassandreStrategyInter
      *
      * @param orderId order id
      * @return true if cancelled
-     * @deprecated use {@link #cancelOrder(String, CurrencyPairDTO)}
+     * @deprecated use {@link #cancelOrder(Order)}
      */
     @Deprecated(forRemoval = true)
     boolean cancelOrder(final String orderId) {
@@ -537,11 +524,11 @@ public abstract class GenericCassandreStrategy implements CassandreStrategyInter
     /**
      * Cancel order.
      *
-     * @param orderId order id
+     * @param order the order to cancel
      * @return true if cancelled
      */
-    boolean cancelOrder(final String orderId, final CurrencyPairDTO currencyPairDTO) {
-        return tradeService.cancelOrder(orderId, currencyPairDTO);
+    boolean cancelOrder(final Order order) {
+        return tradeService.cancelOrder(order);
     }
 
     /**

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/coinbasepro/TradeServiceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/coinbasepro/TradeServiceTest.java
@@ -64,7 +64,7 @@ public class TradeServiceTest extends BaseTest {
 
     @BeforeEach
     public void setUp() {
-        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId()));
+        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId(), order.getCurrencyPair()));
     }
 
     @Test
@@ -133,7 +133,7 @@ public class TradeServiceTest extends BaseTest {
         assertTrue(order1.get().getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
 
         // Cancel the order.
-        tradeService.cancelOrder(result1.getOrder().getOrderId());
+        tradeService.cancelOrder(result1.getOrder().getOrderId(), cp);
     }
 
     @Test
@@ -151,13 +151,13 @@ public class TradeServiceTest extends BaseTest {
         await().untilAsserted(() -> assertTrue(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order.
-        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
 
         // The order must have disappeared.
         await().untilAsserted(() -> assertFalse(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order again and check it gives false.
-        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
     }
 
     @Test

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/coinbasepro/TradeServiceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/coinbasepro/TradeServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,6 +17,7 @@ import tech.cassandre.trading.bot.dto.util.CurrencyPairDTO;
 import tech.cassandre.trading.bot.service.TradeService;
 import tech.cassandre.trading.bot.test.util.junit.BaseTest;
 import tech.cassandre.trading.bot.test.util.strategies.TestableCassandreStrategy;
+import tech.cassandre.trading.bot.util.mapper.OrderMapper;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -62,9 +64,11 @@ public class TradeServiceTest extends BaseTest {
     @Autowired
     private TradeService tradeService;
 
+    private OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
+    
     @BeforeEach
     public void setUp() {
-        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId(), order.getCurrencyPair()));
+        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(orderMapper.mapToOrder(order)));
     }
 
     @Test
@@ -115,25 +119,26 @@ public class TradeServiceTest extends BaseTest {
 
         // =============================================================================================================
         // Getting the order and testing the data.
-        final Optional<OrderDTO> order1 = tradeService.getOrders().stream().filter(o -> o.getOrderId().equals(result1.getOrder().getOrderId())).findFirst();
-        assertTrue(order1.isPresent());
-        assertNotNull(order1.get().getOrderId());
-        assertEquals(result1.getOrder().getOrderId(), order1.get().getOrderId());
-        assertEquals(BID, order1.get().getType());
-        assertEquals(cp, order1.get().getCurrencyPair());
-        assertEquals(0, order1.get().getAmount().getValue().compareTo(new BigDecimal("0.01")));
-        assertEquals(cp.getBaseCurrency(), order1.get().getAmount().getCurrency());
-        assertEquals(0, order1.get().getLimitPrice().getValue().compareTo(new BigDecimal("0.0001")));
-        assertEquals(cp.getQuoteCurrency(), order1.get().getLimitPrice().getCurrency());
-        assertNull(order1.get().getLeverage());
-        assertEquals(PENDING_NEW, order1.get().getStatus());
-        assertNull(order1.get().getUserReference());
-        assertNotNull(order1.get().getTimestamp());
-        assertTrue(order1.get().getTimestamp().isAfter(ZonedDateTime.now().minusMinutes(1)));
-        assertTrue(order1.get().getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
+        final Optional<OrderDTO> result = tradeService.getOrders().stream().filter(o -> o.getOrderId().equals(result1.getOrder().getOrderId())).findFirst();
+        assertTrue(result.isPresent());
+        OrderDTO order1 = result.get();
+        assertNotNull(order1.getOrderId());
+        assertEquals(result1.getOrder().getOrderId(), order1.getOrderId());
+        assertEquals(BID, order1.getType());
+        assertEquals(cp, order1.getCurrencyPair());
+        assertEquals(0, order1.getAmount().getValue().compareTo(new BigDecimal("0.01")));
+        assertEquals(cp.getBaseCurrency(), order1.getAmount().getCurrency());
+        assertEquals(0, order1.getLimitPrice().getValue().compareTo(new BigDecimal("0.0001")));
+        assertEquals(cp.getQuoteCurrency(), order1.getLimitPrice().getCurrency());
+        assertNull(order1.getLeverage());
+        assertEquals(PENDING_NEW, order1.getStatus());
+        assertNull(order1.getUserReference());
+        assertNotNull(order1.getTimestamp());
+        assertTrue(order1.getTimestamp().isAfter(ZonedDateTime.now().minusMinutes(1)));
+        assertTrue(order1.getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
 
         // Cancel the order.
-        tradeService.cancelOrder(result1.getOrder().getOrderId(), cp);
+        tradeService.cancelOrder(orderMapper.mapToOrder(order1));
     }
 
     @Test
@@ -151,13 +156,13 @@ public class TradeServiceTest extends BaseTest {
         await().untilAsserted(() -> assertTrue(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order.
-        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
+        assertTrue(tradeService.cancelOrder(orderMapper.mapToOrder(result1.getOrder())));
 
         // The order must have disappeared.
         await().untilAsserted(() -> assertFalse(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order again and check it gives false.
-        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
+        assertFalse(tradeService.cancelOrder(orderMapper.mapToOrder(result1.getOrder())));
     }
 
     @Test

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/gemini/TradeServiceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/gemini/TradeServiceTest.java
@@ -64,7 +64,7 @@ public class TradeServiceTest extends BaseTest {
 
     @BeforeEach
     public void setUp() {
-        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId()));
+        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId(), order.getCurrencyPair()));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class TradeServiceTest extends BaseTest {
         assertTrue(order1.get().getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
 
         // Cancel the order.
-        tradeService.cancelOrder(result1.getOrder().getOrderId());
+        tradeService.cancelOrder(result1.getOrder().getOrderId(), cp);
     }
 
     @Test
@@ -156,13 +156,13 @@ public class TradeServiceTest extends BaseTest {
         await().untilAsserted(() -> assertTrue(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order.
-        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
 
         // The order must have disappeared.
         await().untilAsserted(() -> assertFalse(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order again and check it gives false.
-        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
     }
 
     @Test

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/kucoin/TradeServiceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/kucoin/TradeServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,6 +16,7 @@ import tech.cassandre.trading.bot.dto.util.CurrencyPairDTO;
 import tech.cassandre.trading.bot.service.TradeService;
 import tech.cassandre.trading.bot.test.util.junit.BaseTest;
 import tech.cassandre.trading.bot.test.util.strategies.TestableCassandreStrategy;
+import tech.cassandre.trading.bot.util.mapper.OrderMapper;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -59,10 +61,12 @@ public class TradeServiceTest extends BaseTest {
 
     @Autowired
     private TradeService tradeService;
+    
+    private OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
 
     @BeforeEach
     public void setUp() {
-        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId(), order.getCurrencyPair()));
+        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(orderMapper.mapToOrder(order)));
     }
 
     @Test
@@ -113,25 +117,28 @@ public class TradeServiceTest extends BaseTest {
 
         // =============================================================================================================
         // Getting the order and testing the data.
-        final Optional<OrderDTO> order1 = tradeService.getOrders().stream().filter(o -> o.getOrderId().equals(result1.getOrder().getOrderId())).findFirst();
-        assertTrue(order1.isPresent());
-        assertNotNull(order1.get().getOrderId());
-        assertEquals(result1.getOrder().getOrderId(), order1.get().getOrderId());
-        assertEquals(BID, order1.get().getType());
-        assertEquals(cp, order1.get().getCurrencyPair());
-        assertEquals(0, order1.get().getAmount().getValue().compareTo(new BigDecimal("0.0001")));
-        assertEquals(cp.getBaseCurrency(), order1.get().getAmount().getCurrency());
-        assertEquals(0, order1.get().getLimitPrice().getValue().compareTo(new BigDecimal("0.000001")));
-        assertEquals(cp.getQuoteCurrency(), order1.get().getLimitPrice().getCurrency());
-        assertNull(order1.get().getLeverage());
-        assertEquals(PENDING_NEW, order1.get().getStatus());
-        assertNull(order1.get().getUserReference());
-        assertNotNull(order1.get().getTimestamp());
-        assertTrue(order1.get().getTimestamp().isAfter(ZonedDateTime.now().minusMinutes(1)));
-        assertTrue(order1.get().getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
+        final Optional<OrderDTO> result = tradeService.getOrders().stream().filter(o -> o.getOrderId().equals(result1.getOrder().getOrderId())).findFirst();
+        assertTrue(result.isPresent());
+        OrderDTO order1 = result.get();
+        
+        assertNotNull(order1.getOrderId());
+        assertEquals(result1.getOrder().getOrderId(), order1.getOrderId());
+        assertEquals(BID, order1.getType());
+        assertEquals(cp, order1.getCurrencyPair());
+        assertEquals(0, order1.getAmount().getValue().compareTo(new BigDecimal("0.0001")));
+        assertEquals(cp.getBaseCurrency(), order1.getAmount().getCurrency());
+        assertEquals(0, order1.getLimitPrice().getValue().compareTo(new BigDecimal("0.000001")));
+        assertEquals(cp.getQuoteCurrency(), order1.getLimitPrice().getCurrency());
+        assertNull(order1.getLeverage());
+        assertEquals(PENDING_NEW, order1.getStatus());
+        assertNull(order1.getUserReference());
+        assertNotNull(order1.getTimestamp());
+        assertTrue(order1.getTimestamp().isAfter(ZonedDateTime.now().minusMinutes(1)));
+        assertTrue(order1.getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
 
         // Cancel the order.
-        tradeService.cancelOrder(result1.getOrder().getOrderId(), cp);
+        
+        tradeService.cancelOrder(orderMapper.mapToOrder(order1));
     }
 
     @Test
@@ -148,10 +155,10 @@ public class TradeServiceTest extends BaseTest {
         await().untilAsserted(() -> assertTrue(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order.
-        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
+        assertTrue(tradeService.cancelOrder(orderMapper.mapToOrder(result1.getOrder())));
 
         // Cancel the order again and check it gives false.
-        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
+        assertFalse(tradeService.cancelOrder(orderMapper.mapToOrder(result1.getOrder())));
     }
 
     @Test

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/kucoin/TradeServiceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/integration/kucoin/TradeServiceTest.java
@@ -62,7 +62,7 @@ public class TradeServiceTest extends BaseTest {
 
     @BeforeEach
     public void setUp() {
-        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId()));
+        tradeService.getOrders().forEach(order -> tradeService.cancelOrder(order.getOrderId(), order.getCurrencyPair()));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class TradeServiceTest extends BaseTest {
         assertTrue(order1.get().getTimestamp().isBefore(ZonedDateTime.now().plusMinutes(1)));
 
         // Cancel the order.
-        tradeService.cancelOrder(result1.getOrder().getOrderId());
+        tradeService.cancelOrder(result1.getOrder().getOrderId(), cp);
     }
 
     @Test
@@ -148,10 +148,10 @@ public class TradeServiceTest extends BaseTest {
         await().untilAsserted(() -> assertTrue(tradeService.getOrders().stream().anyMatch(o -> o.getOrderId().equals(result1.getOrder().getOrderId()))));
 
         // Cancel the order.
-        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertTrue(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
 
         // Cancel the order again and check it gives false.
-        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId()));
+        assertFalse(tradeService.cancelOrder(result1.getOrder().getOrderId(), cp));
     }
 
     @Test


### PR DESCRIPTION
Issue 584: https://github.com/cassandre-tech/cassandre-trading-bot/issues/584

Applied requested fixes
Use Order instead of CurrencyPair. Support all current tradex service implementations.