### PR TITLE
FIX: subscriber exception should be caught

### DIFF
--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/StrategiesAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/StrategiesAutoConfiguration.java
@@ -299,11 +299,21 @@ public class StrategiesAutoConfiguration extends BaseConfiguration {
                     strategy.initialize();
 
                     // Connecting flux to strategy.
-                    connectableAccountFlux.subscribe(strategy::accountsUpdates);
-                    connectablePositionFlux.subscribe(strategy::positionsUpdates);
-                    connectableOrderFlux.subscribe(strategy::ordersUpdates);
-                    connectableTradeFlux.subscribe(strategy::tradesUpdates);
-                    connectableTickerFlux.subscribe(strategy::tickersUpdates);
+                    connectableAccountFlux.subscribe(strategy::accountsUpdates, throwable -> {
+                        logger.error("AccountsUpdates failing: {}", throwable.getMessage());
+                    });
+                    connectablePositionFlux.subscribe(strategy::positionsUpdates, throwable -> {
+                        logger.error("PositionsUpdates failing: {}", throwable.getMessage());
+                    });
+                    connectableOrderFlux.subscribe(strategy::ordersUpdates, throwable -> {
+                        logger.error("OrdersUpdates failing: {}", throwable.getMessage());
+                    });
+                    connectableTradeFlux.subscribe(strategy::tradesUpdates, throwable -> {
+                        logger.error("TradesUpdates failing: {}", throwable.getMessage());
+                    });
+                    connectableTickerFlux.subscribe(strategy::tickersUpdates, throwable -> {
+                        logger.error("TickersUpdates failing: {}", throwable.getMessage());
+                    });
                 });
 
         // Start flux.


### PR DESCRIPTION
FIX: subscriber exception should be caught in a safe way when using shared-flux.