### PR TITLE
Support for tickers coming from WebSocket streaming XChange driver

### DIFF
--- a/spring-boot-starter/autoconfigure/pom.xml
+++ b/spring-boot-starter/autoconfigure/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-kucoin</artifactId>
-            <version>5.0.13</version>
+            <version>${xchange.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- For Coinbase integration tests -->
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-gemini</artifactId>
-            <version>5.0.13</version>
+            <version>${xchange.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- For Binance integration tests -->
@@ -160,6 +160,12 @@
             <artifactId>xchange-binance</artifactId>
             <version>${xchange.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.knowm.xchange</groupId>
+            <artifactId>xchange-stream-core</artifactId>
+            <version>${xchange.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <!-- =========================================================================================================== -->

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/batch/TickerStreamFlux.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/batch/TickerStreamFlux.java
@@ -1,0 +1,73 @@
+package tech.cassandre.trading.bot.batch;
+
+import info.bitrich.xchangestream.core.StreamingExchange;
+import io.reactivex.disposables.Disposable;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.springframework.context.ApplicationContext;
+import tech.cassandre.trading.bot.dto.market.TickerDTO;
+import tech.cassandre.trading.bot.dto.util.CurrencyPairDTO;
+import tech.cassandre.trading.bot.strategy.CassandreStrategy;
+import tech.cassandre.trading.bot.strategy.internal.CassandreStrategyInterface;
+import tech.cassandre.trading.bot.util.base.batch.BaseFlux;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Ticker stream flux - push {@link TickerDTO}.
+ * It registers for tickers streams from the exchange.
+ * To get a deep understanding of how it works, read the documentation of {@link BaseFlux}.
+ */
+//@RequiredArgsConstructor
+public class TickerStreamFlux extends BaseFlux<TickerDTO> {
+
+    /** ticker subscriptions. */
+    private final Set<Disposable> tickerSubscriptions = new LinkedHashSet<>();
+
+    private void processTicker(final Ticker ticker) {
+        TickerDTO tickerDTO = TICKER_MAPPER.mapToTickerDTO(ticker);
+        if (this.fluxSink != null) {
+            emitValue(tickerDTO);
+        }
+    }
+
+    public TickerStreamFlux(
+            final ApplicationContext applicationContext,
+            final StreamingExchange streamingExchange) {
+
+        logger.info("Starting stream ticker flux");
+        // We retrieve the list of currency pairs asked by all strategies.
+        // Some users coded a getRequestedCurrencyPairs() that returns different results.
+        final LinkedHashSet<CurrencyPairDTO> requestedCurrencyPairs = applicationContext
+                .getBeansWithAnnotation(CassandreStrategy.class)
+                .values()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(object -> (CassandreStrategyInterface) object)
+                .map(CassandreStrategyInterface::getRequestedCurrencyPairs)
+                .flatMap(Set::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        // Subscribe to live trades update.
+        for (var currency : requestedCurrencyPairs) {
+            CurrencyPair currencyPair = new CurrencyPair(currency.getBaseCurrency().getCurrencyCode(), currency.getQuoteCurrency().getCode());
+            Disposable task = streamingExchange.getStreamingMarketDataService()
+                    .getTicker(currencyPair)
+                    .subscribe(
+                            ticker -> processTicker(ticker),
+                            throwable -> logger.error("Error in trade subscription", throwable));
+            tickerSubscriptions.add(task);
+        }
+    }
+
+    @Override
+    protected final Set<TickerDTO> getNewValues() {
+
+        Set<TickerDTO> result = new LinkedHashSet<>();
+        return result;
+    }
+
+}

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -145,6 +145,7 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
 
             // Creates XChange services.
             if (exchangeParameters.isTickerStreamEnabled()) {
+                exchangeSpecification.setShouldLoadRemoteMetaData(true); // this must be set or Streaming will not download currencies by default
                 // Create Streaming XChange services
                 xChangeExchange = StreamingExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
             } else {

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -1,9 +1,13 @@
 package tech.cassandre.trading.bot.configuration;
 
+import info.bitrich.xchangestream.core.ProductSubscription;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import lombok.RequiredArgsConstructor;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -16,6 +20,7 @@ import tech.cassandre.trading.bot.batch.AccountFlux;
 import tech.cassandre.trading.bot.batch.OrderFlux;
 import tech.cassandre.trading.bot.batch.PositionFlux;
 import tech.cassandre.trading.bot.batch.TickerFlux;
+import tech.cassandre.trading.bot.batch.TickerStreamFlux;
 import tech.cassandre.trading.bot.batch.TradeFlux;
 import tech.cassandre.trading.bot.repository.OrderRepository;
 import tech.cassandre.trading.bot.repository.PositionRepository;
@@ -30,12 +35,16 @@ import tech.cassandre.trading.bot.service.TradeService;
 import tech.cassandre.trading.bot.service.TradeServiceXChangeImplementation;
 import tech.cassandre.trading.bot.service.UserService;
 import tech.cassandre.trading.bot.service.UserServiceXChangeImplementation;
+import tech.cassandre.trading.bot.strategy.CassandreStrategy;
+import tech.cassandre.trading.bot.strategy.internal.CassandreStrategyInterface;
 import tech.cassandre.trading.bot.util.base.configuration.BaseConfiguration;
 import tech.cassandre.trading.bot.util.exception.ConfigurationException;
 import tech.cassandre.trading.bot.util.parameters.ExchangeParameters;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * ExchangeConfiguration configures the exchange connection.
@@ -96,6 +105,9 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
     /** Ticker flux. */
     private TickerFlux tickerFlux;
 
+    /** Ticker stream flux. */
+    private TickerStreamFlux tickerStreamFlux;
+
     /** Order flux. */
     private OrderFlux orderFlux;
 
@@ -132,10 +144,31 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
             }
 
             // Creates XChange services.
-            xChangeExchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
+            if (exchangeParameters.isTickerStreamEnabled()) {
+                // Create Streaming XChange services
+                xChangeExchange = StreamingExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
+            } else {
+                xChangeExchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
+            }
             xChangeAccountService = xChangeExchange.getAccountService();
             xChangeMarketDataService = xChangeExchange.getMarketDataService();
             xChangeTradeService = xChangeExchange.getTradeService();
+
+            if (exchangeParameters.isTickerStreamEnabled()) {
+                ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+                applicationContext
+                        .getBeansWithAnnotation(CassandreStrategy.class)
+                        .values()
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .map(object -> (CassandreStrategyInterface) object)
+                        .map(CassandreStrategyInterface::getRequestedCurrencyPairs)
+                        .flatMap(Set::stream)
+                        .forEach(pair -> builder.addTicker(new CurrencyPair(pair.getBaseCurrency().getCurrencyCode(), pair.getQuoteCurrency().getCode())));
+
+                // Connect to the Exchange WebSocket API. Here we use a blocking wait.
+                ((StreamingExchange) xChangeExchange).connect(builder.build()).blockingAwait();
+            }
 
             // Force login to check credentials.
             logger.info("Exchange connection with driver {}", exchangeParameters.getDriverClassName());
@@ -261,7 +294,7 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
     @Bean
     @DependsOn("getXChangeMarketDataService")
     public MarketService getMarketService() {
-        if (marketService == null) {
+        if (marketService == null && !exchangeParameters.isTickerStreamEnabled()) {
             marketService = new MarketServiceXChangeImplementation(
                     exchangeParameters.getRates().getTickerValueInMs(),
                     getXChangeMarketDataService());
@@ -308,10 +341,23 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
     @Bean
     @DependsOn("getMarketService")
     public TickerFlux getTickerFlux() {
-        if (tickerFlux == null) {
+        if (tickerFlux == null && !exchangeParameters.isTickerStreamEnabled()) {
             tickerFlux = new TickerFlux(applicationContext, getMarketService());
         }
         return tickerFlux;
+    }
+
+    /**
+     * Getter for tickerStreamFlux.
+     *
+     * @return tickerStreamFlux
+     */
+    @Bean
+    public TickerStreamFlux getTickerStreamFlux() {
+        if (tickerStreamFlux == null && exchangeParameters.isTickerStreamEnabled()) {
+            tickerStreamFlux = new TickerStreamFlux(applicationContext, (StreamingExchange) getXChangeExchange());
+        }
+        return tickerStreamFlux;
     }
 
     /**

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ScheduleAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ScheduleAutoConfiguration.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ScheduleAutoConfiguration extends BaseConfiguration {
 
     /** Scheduler pool size. */
-    private static final int SCHEDULER_POOL_SIZE = 3;
+    private static final int SCHEDULER_POOL_SIZE = 4;
 
     /** Start delay in milliseconds (1 000 ms = 1 second). */
     private static final int START_DELAY_IN_MILLISECONDS = 1_000;
@@ -69,7 +69,7 @@ public class ScheduleAutoConfiguration extends BaseConfiguration {
      */
     @Scheduled(initialDelay = START_DELAY_IN_MILLISECONDS, fixedDelay = 1)
     public void tickerFluxUpdate() {
-        if (enabled.get()) {
+        if (enabled.get() && tickerFlux != null) {
             tickerFlux.update();
         }
     }

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/StrategiesAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/StrategiesAutoConfiguration.java
@@ -12,6 +12,7 @@ import tech.cassandre.trading.bot.batch.AccountFlux;
 import tech.cassandre.trading.bot.batch.OrderFlux;
 import tech.cassandre.trading.bot.batch.PositionFlux;
 import tech.cassandre.trading.bot.batch.TickerFlux;
+import tech.cassandre.trading.bot.batch.TickerStreamFlux;
 import tech.cassandre.trading.bot.batch.TradeFlux;
 import tech.cassandre.trading.bot.domain.ImportedCandle;
 import tech.cassandre.trading.bot.domain.ImportedTicker;
@@ -110,6 +111,9 @@ public class StrategiesAutoConfiguration extends BaseConfiguration {
     /** Ticker flux. */
     private final TickerFlux tickerFlux;
 
+    /** Ticker Stream flux. */
+    private final TickerStreamFlux tickerStreamFlux;
+
     /** Order flux. */
     private final OrderFlux orderFlux;
 
@@ -155,8 +159,13 @@ public class StrategiesAutoConfiguration extends BaseConfiguration {
         final ConnectableFlux<Set<AccountDTO>> connectableAccountFlux = accountFlux.getFlux().publish();
         final ConnectableFlux<Set<PositionDTO>> connectablePositionFlux = positionFlux.getFlux().publish();
         final ConnectableFlux<Set<OrderDTO>> connectableOrderFlux = orderFlux.getFlux().publish();
-        final ConnectableFlux<Set<TickerDTO>> connectableTickerFlux = tickerFlux.getFlux().publish();
         final ConnectableFlux<Set<TradeDTO>> connectableTradeFlux = tradeFlux.getFlux().publish();
+        final ConnectableFlux<Set<TickerDTO>> connectableTickerFlux;
+        if (exchangeParameters.isTickerStreamEnabled()) {
+            connectableTickerFlux = tickerStreamFlux.getFlux().publish();
+        } else {
+            connectableTickerFlux = tickerFlux.getFlux().publish();
+        }
 
         // =============================================================================================================
         // Configuring strategies.
@@ -447,5 +456,4 @@ public class StrategiesAutoConfiguration extends BaseConfiguration {
         }
         return Collections.emptyList();
     }
-
 }

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/parameters/ExchangeParameters.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/parameters/ExchangeParameters.java
@@ -90,6 +90,12 @@ public class ExchangeParameters {
 
     }
 
+    /** Checks if streams are enabled for tickers.
+     * @return Returns true if ticker rate is set to 0 and XChange driver name contains 'stream' */
+    public final boolean isTickerStreamEnabled() {
+        return getRates().getTickerValueInMs() == 0 && driverClassName.contains("stream");
+    }
+
     /** Exchange API rate calls. */
     @Validated
     @Getter
@@ -137,7 +143,7 @@ public class ExchangeParameters {
          * @return trade rate value in ms
          */
         public long getTradeValueInMs() {
-            return getRateValue(ticker);
+            return getRateValue(trade);
         }
 
         /**


### PR DESCRIPTION
Enables stream of tickers from the exchange. Configuration requires a stream driver and the ticker rate to 0
example application.properties settings:
cassandre.trading.bot.exchange.driver-class-name=info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingExchange
cassandre.trading.bot.exchange.rates.ticker=0