### PR TITLE
Updated to Java 21, Spring Boot 3.5.3, XChange 5.2.2, GraphQL 9.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<spring.version>3.5.3</spring.version>
 		<reactor.version>2024.0.7</reactor.version>
 		<xchange.version>5.2.2</xchange.version>
-		<bucket4j.version>8.0.1</bucket4j.version>
+		<bucket4j.version>8.14.0</bucket4j.version>
 		<liquibase.version>4.31.1</liquibase.version>
 		<opencsv.version>5.9</opencsv.version>
 		<jakarta.ws.rs.version>3.1.0</jakarta.ws.rs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,6 @@
 							<goal>sign</goal>
 						</goals>
 						<configuration>
-							<skip>true</skip>
 							<!-- Prevent `gpg` from using pinentry programs -->
 							<gpgArguments>
 								<arg>--pinentry-mode</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
 		<!-- Core -->
 		<spring.version>3.5.3</spring.version>
-		<reactor.version>Dysprosium-SR25</reactor.version>
+		<reactor.version>2024.0.7</reactor.version>
 		<xchange.version>5.2.2</xchange.version>
 		<bucket4j.version>8.0.1</bucket4j.version>
 		<liquibase.version>4.31.1</liquibase.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.5</version>
+		<version>3.5.3</version>
 		<relativePath/>
 	</parent>
 	<!-- =========================================================================================================== -->
@@ -64,52 +64,52 @@
 	<!-- Project configuration -->
 	<properties>
 		<!-- Java build configuration -->
-		<java.version>17</java.version>
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.source>17</maven.compiler.source>
+		<java.version>21</java.version>
+		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- Libraries releases -->
 
 		<!-- Core -->
-		<spring.version>3.3.5</spring.version>
+		<spring.version>3.5.3</spring.version>
 		<reactor.version>Dysprosium-SR25</reactor.version>
-		<xchange.version>5.0.13</xchange.version>
+		<xchange.version>5.2.2</xchange.version>
 		<bucket4j.version>8.0.1</bucket4j.version>
-		<liquibase.version>4.29.1</liquibase.version>
+		<liquibase.version>4.31.1</liquibase.version>
 		<opencsv.version>5.9</opencsv.version>
-		<javax.ws.rs.version>2.1.1</javax.ws.rs.version>
+		<jakarta.ws.rs.version>3.1.0</jakarta.ws.rs.version>
 
 		<!-- Core utils -->
-		<lombok.version>1.18.34</lombok.version>
+		<lombok.version>1.18.38</lombok.version>
 		<lombok.mapstruct.version>0.2.0</lombok.mapstruct.version>
-		<mapstruct.version>1.6.0</mapstruct.version>
-		<guava.version>33.3.0-jre</guava.version>
+		<mapstruct.version>1.6.3</mapstruct.version>
+		<guava.version>33.2.1-jre</guava.version>
 
 		<!-- Tests -->
 		<junit-pioneer.version>2.2.0</junit-pioneer.version>
 		<awaitility.version>4.2.2</awaitility.version>
 		<hsqldb.version>2.7.3</hsqldb.version>
-		<jackson.version>2.15.2</jackson.version>
+		<jackson.version>2.19.1</jackson.version>
 
 		<!-- GraphQL API -->
-		<graphql-dgs.version>9.1.3</graphql-dgs.version>
+		<graphql-dgs.version>9.2.2</graphql-dgs.version>
 
 		<!-- Maven -->
 		<maven.checkstyle.plugin.version>3.5.0</maven.checkstyle.plugin.version>
 		<maven.graphqlcodegen.plugin.version>1.18</maven.graphqlcodegen.plugin.version>
 		<maven.puppycrawl.checkstyle.version>10.20.0</maven.puppycrawl.checkstyle.version>
 		<maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
-		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-		<maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
-		<maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
+		<maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
+		<maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
+		<maven.jacoco.plugin.version>0.8.13</maven.jacoco.plugin.version>
 		<maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
 		<maven.lombok.plugin.version>1.18.20.0</maven.lombok.plugin.version>
 		<maven.source.plugin.version>3.3.1</maven.source.plugin.version>
-		<maven.javadoc.plugin.version>3.10.1</maven.javadoc.plugin.version>
-		<maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
-		<maven.archetype-packaging.version>3.2.1</maven.archetype-packaging.version>
+		<maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
+		<maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
+		<maven.archetype-packaging.version>3.4.0</maven.archetype-packaging.version>
 	</properties>
 	<!-- =========================================================================================================== -->
 
@@ -181,6 +181,7 @@
 							<goal>sign</goal>
 						</goals>
 						<configuration>
+							<skip>true</skip>
 							<!-- Prevent `gpg` from using pinentry programs -->
 							<gpgArguments>
 								<arg>--pinentry-mode</arg>

--- a/spring-boot-starter/autoconfigure/pom.xml
+++ b/spring-boot-starter/autoconfigure/pom.xml
@@ -94,12 +94,18 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>${opencsv.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax.ws.rs.version}</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs.version}</version>
         </dependency>
 
         <!-- Tests -->
@@ -165,7 +171,7 @@
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-binance</artifactId>
             <version>${xchange.version}</version>
-            <scope>test</scope>
+            <scope>test</scope> <!-- For 5.2.2 is needed to put in exchangeSpecification.setExchangeSpecificParametersItem an enum ExchangeType -->
         </dependency>
         <dependency>
             <groupId>org.knowm.xchange</groupId>

--- a/spring-boot-starter/autoconfigure/pom.xml
+++ b/spring-boot-starter/autoconfigure/pom.xml
@@ -65,8 +65,8 @@
 
         <!-- Util -->
         <dependency>
-            <groupId>com.github.vladimir-bukhtoyarov</groupId>
-            <artifactId>bucket4j-core</artifactId>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
             <version>${bucket4j.version}</version>
         </dependency>
         <dependency>

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/batch/TickerStreamFlux.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/batch/TickerStreamFlux.java
@@ -1,7 +1,7 @@
 package tech.cassandre.trading.bot.batch;
 
 import info.bitrich.xchangestream.core.StreamingExchange;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.springframework.context.ApplicationContext;

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -142,6 +142,8 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
             if (exchangeParameters.getPort() != null) {
                 exchangeSpecification.setPort(Integer.parseInt(exchangeParameters.getPort()));
             }
+            // must be set for binance
+            this.configureBinanceWalletType(exchangeClass, exchangeSpecification);
 
             // Creates XChange services.
             if (exchangeParameters.isTickerStreamEnabled()) {
@@ -215,6 +217,50 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
                     .concat(exchangeParameters.getDriverClassName().substring(1).toLowerCase())   // The rest of the exchange name (ucoin).
                     .concat("Exchange");                                                                // Adding exchange (Exchange).
         }
+    }
+
+    /**
+     * Since xchange-binance 5.2.0, the method {@code BinanceExchange::concludeHostParams}
+     * requires setting a wallet type such as {@code SPOT}, {@code FUTURES}, or {@code INVERSE}. <br>
+     * Therefore, Cassandre must explicitly define which type to use. <p>
+     * To avoid a strong compile-time dependency on xchange-binance, this method uses reflection.
+     *
+     * @param exchangeClass The XChange {@code Exchange} class.
+     * @param spec          The {@code ExchangeSpecification} to configure.
+     */
+    private void configureBinanceWalletType(final Class<? extends Exchange> exchangeClass, final ExchangeSpecification spec) {
+        try {
+            Class<?> binanceExchangeClass = Class.forName("org.knowm.xchange.binance.BinanceExchange");
+
+            if (binanceExchangeClass.isAssignableFrom(exchangeClass)) {
+                Object spotValue = getSpotEnumConstant();
+                spec.setExchangeSpecificParametersItem("Exchange_Type", spotValue);
+            }
+
+        } catch (ClassNotFoundException | IllegalArgumentException e) {
+            logger.debug("Exchange driver is not from Binance, skipping wallet specific configuration.");
+        }
+    }
+
+    /**
+     * Retrieves the {@code SPOT} enum constant from {@code org.knowm.xchange.binance.dto.ExchangeType}
+     * using reflection, in order to avoid a direct dependency on the Binance module.
+     *
+     * @param <E> The expected enum type.
+     * @return The {@code SPOT} enum constant from {@code ExchangeType}.
+     * @throws ClassNotFoundException   If the {@code ExchangeType} enum class is not found.
+     * @throws IllegalArgumentException If the {@code SPOT} constant does not exist in {@code ExchangeType}.
+     */
+    @SuppressWarnings("unchecked")
+    private <E extends Enum<E>> E getSpotEnumConstant() throws ClassNotFoundException, IllegalArgumentException {
+
+        Class<?> rawClass = Class.forName("org.knowm.xchange.binance.dto.ExchangeType");
+
+        if (!rawClass.isEnum()) {
+            throw new IllegalStateException("Expected enum type: " + "org.knowm.xchange.binance.dto.ExchangeType");
+        }
+
+        return Enum.valueOf((Class<E>) rawClass, "SPOT");
     }
 
     /**

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/configuration/ExchangeAutoConfiguration.java
@@ -132,7 +132,7 @@ public class ExchangeAutoConfiguration extends BaseConfiguration {
             exchangeSpecification.setApiKey(exchangeParameters.getKey());
             exchangeSpecification.setSecretKey(exchangeParameters.getSecret());
             exchangeSpecification.getResilience().setRateLimiterEnabled(true);
-            exchangeSpecification.setExchangeSpecificParametersItem("Use_Sandbox", exchangeParameters.getModes().getSandbox());
+            exchangeSpecification.setExchangeSpecificParametersItem(Exchange.USE_SANDBOX, exchangeParameters.getModes().getSandbox());
             exchangeSpecification.setExchangeSpecificParametersItem("passphrase", exchangeParameters.getPassphrase());
             exchangeSpecification.setProxyHost(exchangeParameters.getProxyHost());
             exchangeSpecification.setProxyPort(exchangeParameters.getProxyPort());

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/dto/user/AccountFeatureDTO.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/dto/user/AccountFeatureDTO.java
@@ -15,6 +15,8 @@ public enum AccountFeatureDTO {
     MARGIN_TRADING,
 
     /** You can fund other margin traders with funds allocated to this wallet to earn an interest. */
-    MARGIN_FUNDING
+    MARGIN_FUNDING,
 
+    /** Wallet for futures platform. */
+    FUTURES_TRADING;
 }

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/dto/util/CurrencyPairDTO.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/dto/util/CurrencyPairDTO.java
@@ -51,7 +51,7 @@ public class CurrencyPairDTO {
      * @param currencyPair currency pair
      */
     public CurrencyPairDTO(final CurrencyPair currencyPair) {
-        this(currencyPair.base.toString(), currencyPair.counter.toString());
+        this(currencyPair.getBase().toString(), currencyPair.getCounter().toString());
     }
 
     /**
@@ -108,8 +108,8 @@ public class CurrencyPairDTO {
      */
     public CurrencyPairDTO(final Instrument instrument) {
         final CurrencyPair cp = (CurrencyPair) instrument;
-        this.baseCurrency = new CurrencyDTO(cp.base.getCurrencyCode());
-        this.quoteCurrency = new CurrencyDTO(cp.counter.getCurrencyCode());
+        this.baseCurrency = new CurrencyDTO(cp.getBase().getCurrencyCode());
+        this.quoteCurrency = new CurrencyDTO(cp.getCounter().getCurrencyCode());
         this.baseCurrencyPrecision = DEFAULT_CURRENCY_PRECISION;
         this.quoteCurrencyPrecision = DEFAULT_CURRENCY_PRECISION;
     }
@@ -122,8 +122,8 @@ public class CurrencyPairDTO {
      */
     public CurrencyPairDTO(final Instrument instrument, final int newBaseCurrencyPrecision, final int newQuoteCurrencyPrecision) {
         final CurrencyPair cp = (CurrencyPair) instrument;
-        this.baseCurrency = new CurrencyDTO(cp.base.getCurrencyCode());
-        this.quoteCurrency = new CurrencyDTO(cp.counter.getCurrencyCode());
+        this.baseCurrency = new CurrencyDTO(cp.getBase().getCurrencyCode());
+        this.quoteCurrency = new CurrencyDTO(cp.getCounter().getCurrencyCode());
         this.baseCurrencyPrecision = newBaseCurrencyPrecision;
         this.quoteCurrencyPrecision = newQuoteCurrencyPrecision;
     }

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/ExchangeServiceXChangeImplementation.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/ExchangeServiceXChangeImplementation.java
@@ -23,7 +23,7 @@ public class ExchangeServiceXChangeImplementation extends BaseService implements
     public Set<CurrencyPairDTO> getAvailableCurrencyPairs() {
         logger.debug("Retrieving available currency pairs");
         return exchange.getExchangeMetaData()
-                .getCurrencyPairs()
+                .getInstruments()
                 .keySet()
                 .stream()
                 .peek(cp -> logger.debug(" - {} available", cp))

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/PositionServiceCassandreImplementation.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/PositionServiceCassandreImplementation.java
@@ -34,14 +34,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.math.BigDecimal.ZERO;
-import static java.math.RoundingMode.FLOOR;
+import static java.math.RoundingMode.CEILING;
 import static java.math.RoundingMode.HALF_UP;
 import static tech.cassandre.trading.bot.dto.position.PositionStatusDTO.CLOSED;
 import static tech.cassandre.trading.bot.dto.position.PositionStatusDTO.OPENED;
 import static tech.cassandre.trading.bot.dto.position.PositionStatusDTO.OPENING;
 import static tech.cassandre.trading.bot.dto.position.PositionTypeDTO.LONG;
 import static tech.cassandre.trading.bot.dto.position.PositionTypeDTO.SHORT;
-import static tech.cassandre.trading.bot.util.math.MathConstants.BIGINTEGER_SCALE;
 import static tech.cassandre.trading.bot.util.math.MathConstants.ONE_HUNDRED_BIG_DECIMAL;
 
 /**
@@ -185,7 +184,9 @@ public class PositionServiceCassandreImplementation extends BaseService implemen
                 // We will use those 10 USDT to buy back ETH when the rule is triggered.
                 // CP2: ETH/USDT - 1 ETH costs 2 USDT - We buy 5 ETH, and it will cost us 10 USDT.
                 // We can now use those 10 USDT to buy 5 ETH (amount sold / price).
-                final BigDecimal amountToBuy = positionDTO.getAmountToLock().getValue().divide(ticker.getLast(), HALF_UP).setScale(BIGINTEGER_SCALE, FLOOR);
+                Integer baseCurrencyPrecision = position.get().getBaseCurrencyPrecision(); // You can set in DB to avoid LOT_SIZE error, when exchange set a maximum decimal places to a currency.
+                // e.g. in Binance 0.00105 BTC is allowed (5 decimal places), but 0.001059 is not allowed (6 decimal places)
+                final BigDecimal amountToBuy = positionDTO.getAmountToLock().getValue().divide(ticker.getLast(), HALF_UP).setScale(baseCurrencyPrecision, CEILING);
                 orderCreationResult = tradeService.createBuyMarketOrder(strategy, positionDTO.getCurrencyPair(), amountToBuy);
             }
 

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/PositionServiceCassandreImplementation.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/service/PositionServiceCassandreImplementation.java
@@ -186,7 +186,7 @@ public class PositionServiceCassandreImplementation extends BaseService implemen
                 // We can now use those 10 USDT to buy 5 ETH (amount sold / price).
                 Integer baseCurrencyPrecision = position.get().getBaseCurrencyPrecision(); // You can set in DB to avoid LOT_SIZE error, when exchange set a maximum decimal places to a currency.
                 // e.g. in Binance 0.00105 BTC is allowed (5 decimal places), but 0.001059 is not allowed (6 decimal places)
-                final BigDecimal amountToBuy = positionDTO.getAmountToLock().getValue().divide(ticker.getLast(), HALF_UP).setScale(baseCurrencyPrecision, CEILING);
+                final BigDecimal amountToBuy = positionDTO.getAmountToLock().getValue().divide(ticker.getLast(), HALF_UP).setScale(baseCurrencyPrecision, CEILING); // Changed to CEILING
                 orderCreationResult = tradeService.createBuyMarketOrder(strategy, positionDTO.getCurrencyPair(), amountToBuy);
             }
 

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/internal/CassandreStrategyImplementation.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/strategy/internal/CassandreStrategyImplementation.java
@@ -196,18 +196,22 @@ public abstract class CassandreStrategyImplementation extends BaseStrategy imple
      */
     protected void updatePositionsWithTickersUpdates(final Map<CurrencyPairDTO, TickerDTO> tickers) {
         // We check if any ticker updates a position, and we close if it's time.
-        dependencies.getPositionRepository()
-                .findByStatusNot(CLOSED)
-                .stream()
+        Set<PositionDTO> positionsDtoUpdatedByTicker = dependencies.getPositionRepository().findByStatusNot(CLOSED).stream()
                 .map(POSITION_MAPPER::mapToPositionDTO)
-                // Only the positions of this strategy.
+                // Only the positionsDTO of this strategy.
                 .filter(positionDTO -> positionDTO.getStrategy().getUid().equals(configuration.getStrategyUid()))
                 // Only if we received the ticker used by the position.
                 .filter(positionDTO -> tickers.get(positionDTO.getCurrencyPair()) != null)
                 // We send the ticker corresponding to the currency pair of the position. If it returns true, we emit because price changed.
                 .filter(positionDTO -> positionDTO.tickerUpdate(tickers.get(positionDTO.getCurrencyPair())))
                 .peek(positionDTO -> logger.debug("Position {} updated with ticker {}", positionDTO.getPositionId(), tickers.get(positionDTO.getCurrencyPair())))
-                .peek(positionDTO -> dependencies.getPositionFlux().emitValue(positionDTO))
+                .collect(Collectors.toSet());
+
+        // It is faster to emit all positions at once, because emitting 1 by 1 will do
+        // the path positionUpdates >> onPositionsUpdates >> onPositionsStatusUpdates n times, holding tickersUpdates in this process
+        dependencies.getPositionFlux().emitValues(positionsDtoUpdatedByTicker);
+
+        positionsDtoUpdatedByTicker.stream()
                 // We only use tickers updates to close a position if position is set to autoclose.
                 .filter(PositionDTO::isAutoClose)
                 // We check if the position should be closed, if true, we closed and position service will emit the position.

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/base/service/BaseService.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/base/service/BaseService.java
@@ -18,7 +18,7 @@ public abstract class BaseService extends Base {
      * Construct a base service without rate limit.
      */
     public BaseService() {
-        Bandwidth limit = Bandwidth.simple(1, Duration.ofMillis(1));
+        Bandwidth limit = Bandwidth.builder().capacity(1).refillGreedy(1, Duration.ofMillis(1)).build();
         bucket = Bucket.builder().addLimit(limit).build();
     }
 
@@ -28,7 +28,7 @@ public abstract class BaseService extends Base {
      * @param rate rate in ms
      */
     public BaseService(final long rate) {
-        Bandwidth limit = Bandwidth.simple(1, Duration.ofMillis(rate));
+        Bandwidth limit = Bandwidth.builder().capacity(1).refillGreedy(1, Duration.ofMillis(rate)).build();
         bucket = Bucket.builder().addLimit(limit).build();
     }
 

--- a/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/mapper/CurrencyMapper.java
+++ b/spring-boot-starter/autoconfigure/src/main/java/tech/cassandre/trading/bot/util/mapper/CurrencyMapper.java
@@ -40,8 +40,8 @@ public interface CurrencyMapper {
 
     default CurrencyPairDTO mapToCurrencyPairDTO(Instrument source) {
         final CurrencyPair cp = (CurrencyPair) source;
-        CurrencyDTO base = new CurrencyDTO(cp.base.getCurrencyCode());
-        CurrencyDTO quote = new CurrencyDTO(cp.counter.getCurrencyCode());
+        CurrencyDTO base = new CurrencyDTO(cp.getBase().getCurrencyCode());
+        CurrencyDTO quote = new CurrencyDTO(cp.getCounter().getCurrencyCode());
         return new CurrencyPairDTO(base, quote);
     }
 

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/core/configuration/exchange/BinanceTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/core/configuration/exchange/BinanceTest.java
@@ -1,0 +1,42 @@
+package tech.cassandre.trading.bot.test.core.configuration.exchange;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.Exchange;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tech.cassandre.trading.bot.test.util.junit.BaseTest;
+import tech.cassandre.trading.bot.test.util.junit.configuration.Configuration;
+import tech.cassandre.trading.bot.test.util.junit.configuration.Property;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static tech.cassandre.trading.bot.test.util.junit.configuration.ConfigurationExtension.*;
+
+@SpringBootTest
+@DisplayName("Configuration - Exchange - Binance")
+@Configuration({
+        @Property(key = PARAMETER_EXCHANGE_DRIVER_CLASS_NAME, value = "binance"),
+        @Property(key = PARAMETER_EXCHANGE_SANDBOX, value = "true"),
+        @Property(key = PARAMETER_EXCHANGE_DRY, value = "false"),
+        @Property(key = PARAMETER_EXCHANGE_USERNAME, value = "fake-user"),
+        @Property(key = PARAMETER_EXCHANGE_KEY, value = "VUdQSkMwfad4OIM3rd3oHyVZ3agVrcuUsG1PT8ai6GlfR4d9M7IxKpKHg9AEKbbA"),
+        @Property(key = PARAMETER_EXCHANGE_SECRET, value = "VFkJ0L4drBKZ7Xmf8bILROxYbj86CcOeaZsHxuHMzMjXbl2fS0Ne22dRyxsEVKfo"),
+        @Property(key = PARAMETER_EXCHANGE_RATE_ACCOUNT, value = "100"),
+        @Property(key = PARAMETER_EXCHANGE_RATE_TICKER, value = "100"),
+        @Property(key = PARAMETER_EXCHANGE_RATE_TRADE, value = "100")
+})
+public class BinanceTest extends BaseTest {
+
+    @Autowired
+    private Exchange exchange;
+
+    @Test
+    @DisplayName("Check Binance SPOT wallet ")
+    public void checkWalletSpot() {
+
+        Object type = exchange.getExchangeSpecification().getExchangeSpecificParametersItem("Exchange_Type");
+        assertNotNull(type);
+        assertEquals("SPOT", type.toString());
+    }
+}

--- a/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/core/configuration/exchange/CoinbaseTest.java
+++ b/spring-boot-starter/autoconfigure/src/test/java/tech/cassandre/trading/bot/test/core/configuration/exchange/CoinbaseTest.java
@@ -26,7 +26,7 @@ public class CoinbaseTest extends BaseTest {
             application.run();
             fail("Exception not raised");
         } catch (Exception e) {
-            assertTrue(e.getCause().getMessage().contains("(HTTP status code: 404)"));
+            assertTrue(e.getCause().getMessage().contains("404"));
         }
     }
 

--- a/trading-bot-archetypes/basic-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/trading-bot-archetypes/basic-archetype/src/main/resources/archetype-resources/pom.xml
@@ -13,9 +13,9 @@
 	<!-- =========================================================================================================== -->
 	<!-- Project configuration -->
 	<properties>
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.source>17</maven.compiler.source>
-		<java.version>17</java.version>
+		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<java.version>21</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>


### PR DESCRIPTION
major dependencies updated: 
java 21, spring boot 3.5.3, xchange 5.2.2, graphql 9.2.2;

A lot of other dependencies updated too, check the commits.

- Had to implement few changes on code;
- - A Binance specific change but essential, where ExchangeSpecificParametersItem must have wallet type;
- - added new constant enum in AccountFeatureDTO;
- - copied changes from #1336;
- - added new test class for Binance;

Right now i am using my bot with .jars builded from IntelliJ, and everything is working even GraphQL.

Had to update to Java 21 because I am using TA4J 0.18 in my bot project. And this last TA4J version requires Java 21.


I performed all the tests by `mvn test`

```
[INFO] Reactor Summary for Cassandre trading bot 6.0.3-SNAPSHOT:
[INFO] 
[INFO] Cassandre trading bot .............................. SUCCESS [  0.002 s]
[INFO] Trading bot spring boot autoconfigure .............. SUCCESS [30:50 min]
[INFO] Trading bot spring boot starter .................... SUCCESS [  0.554 s]
[INFO] Trading bot spring boot autoconfigure test ......... SUCCESS [01:09 min]
[INFO] Trading bot spring boot starter test ............... SUCCESS [  0.078 s]
[INFO] Trading bot spring boot autoconfigure - GraphQL API  SUCCESS [ 46.532 s]
[INFO] Trading bot spring boot starter - GraphQL API ...... SUCCESS [  0.115 s]
[INFO] Cassandre trading bot basic archetype .............. SUCCESS [  0.119 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  32:47 min
[INFO] Finished at: 2025-06-30T01:01:12-03:00
[INFO] ------------------------------------------------------------------------
```